### PR TITLE
Add Droidcon NYC 2019 videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It will be handy in case you missed any of the sessions or just want to go re-wa
 - [Android Dev Summit 2019](https://www.youtube.com/playlist?list=PLWz5rJ2EKKc_xXXubDti2eRnIKU0p7wHd)
 - [Droidcon Italy 2019](https://www.youtube.com/playlist?list=PL4ebO4PmeAi6jtfp4QcZCEIQ3mBSgq-ck)
 - [Droidcon London 2019](https://skillsmatter.com/conferences/11785-droidcon-london-2019#skillscasts)
+- [Droidcon NYC 2019](https://www.droidcon.com/videos?path=NewYork%20City)
 - [Droidcon Vietnam 2019](https://www.youtube.com/playlist?list=PL4ebO4PmeAi6jtfp4QcZCEIQ3mBSgq-ck)
 - [Android and Google Play at Google I/O 2019](https://www.youtube.com/playlist?list=PLWz5rJ2EKKc9FfSQIRXEWyWpHD6TtwxMM)
 - [Android Makers 2019](https://www.youtube.com/playlist?list=PLn7H9CUCuXAu5r4kT8RcK8B2GuBqMODX3)


### PR DESCRIPTION
Added NYC Droidcon videos.

I was not able to catch the rule of order for videos in the list. So add it alphabetically after Droidcon London.

Please comment.